### PR TITLE
Fix str vs string error introduced by astropy4.3 (ECSV file dtype checking.)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         include:
         - os: ubuntu-latest
           pippath: ~/.cache/pip

--- a/flows/api/lightcurves.py
+++ b/flows/api/lightcurves.py
@@ -41,13 +41,14 @@ def get_lightcurve(target):
 		params=params,
 		headers={'Authorization': 'Bearer ' + token})
 	r.raise_for_status()
+	text = r.text.replace('str,','string,') # Fix 4.3 issue with str not being mapped to string.
 
 	# Create tempory directory and save the file into there,
 	# then open the file as a Table:
 	with tempfile.TemporaryDirectory() as tmpdir:
 		tmpfile = os.path.join(tmpdir, 'table.ecsv')
 		with open(tmpfile, 'w') as fid:
-			fid.write(r.text)
+			fid.write(text)
 
 		tab = Table.read(tmpfile, format='ascii.ecsv')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@ flake8-tabs >= 2.3.2
 flake8-builtins
 flake8-logging-format
 numpy >= 1.16
-scipy == 1.5.4
-astropy == 4.1
+scipy >= 1.5.4
+astropy >= 4.3
 photutils == 1.1.0; python_version >= '3.7'
 photutils == 1.0.2; python_version < '3.7'
 Bottleneck == 1.3.2
-matplotlib == 3.3.1
-mplcursors == 0.3
+matplotlib >= 3.3.1
+mplcursors >= 0.3
 seaborn
 pandas
 requests
@@ -18,7 +18,7 @@ PyYAML
 psycopg2-binary
 jplephem
 vtk
-scikit-image == 0.17.2
+scikit-image >= 0.17.2
 tqdm
 pytz
 git+https://github.com/obscode/imagematch.git@photutils#egg=imagematch


### PR DESCRIPTION
Astropy 4.3 table module requires string in ecsv headers instead of str for reading from a file.

This PR should be merged before #35 as upgrading to astropy 4.3 will break the lightcurve.py.

Fixes #36 . However, we should ideally fix the entire type checking and update to ECSV V1.0