### PR TITLE
Drop support for python 3.6, change default to 3.8, add support for 3.9 and 3.10 on github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [master, devel]
     tags: 'v*'  # Push events to matching v*, i.e. v1.0, v20.15.10
-  pull_request:
+  pull_request_target:
     branches: [master, devel]
   schedule:
     - cron: '0 6 1 * *'  # once a month in the morning

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+          persist-credentials: true
 
     - name: Setup Python 3.8
       uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, '3.10']
         include:
         - os: ubuntu-latest
           pippath: ~/.cache/pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,18 +20,18 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Setup Python 3.7
+    - name: Setup Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Cache pip
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-py3.7-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-pip-py3.8-${{ hashFiles('requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-pip-py3.7-
+          ${{ runner.os }}-pip-py3.8-
           ${{ runner.os }}-pip-
 
     - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9, 3.10]
         include:
         - os: ubuntu-latest
           pippath: ~/.cache/pip
@@ -144,18 +144,18 @@ jobs:
     - name: Git LFS Pull
       run: git lfs pull
 
-    - name: Setup Python 3.7
+    - name: Setup Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Cache pip
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-py3.7-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-pip-py3.8-${{ hashFiles('requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-pip-py3.7-
+          ${{ runner.os }}-pip-py3.8-
           ${{ runner.os }}-pip-
 
     - name: Install dependencies


### PR DESCRIPTION
Fixes #41 and #27.

Change the yaml file on .github to actions to use python 3.8 by default instead of 3.7 (although I would prefer we move to 3.9 if possible), no longer tests against 3.6, and now tests again 3.9 and 3.10.

Along with this, we should make any changes to repo settings necessary to drop 3.6 and add 3.10. 