### PR TITLE
Fix CI tests failing on PRs from forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [master, devel]
     tags: 'v*'  # Push events to matching v*, i.e. v1.0, v20.15.10
-  pull_request:
+  pull_request_target:
     branches: [master, devel]
   schedule:
     - cron: '0 6 1 * *'  # once a month in the morning
@@ -19,6 +19,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+          persist-credentials: true
 
     - name: Setup Python 3.7
       uses: actions/setup-python@v2


### PR DESCRIPTION
Change tests.yml to use `pull_request_target`, as that it supposed to run the workflow against the base repo instead of against the fork in a safe way.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

Fixes #33 