### PR TITLE
Attempt to Fix CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
+        pip install markupsafe==2.0.1
         grep "numpy" requirements.txt | xargs -I {} pip install "{}"
         pip install -r requirements.txt
 
@@ -109,6 +110,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
+        pip install markupsafe==2.0.1
         grep "numpy" requirements.txt | xargs -I {} pip install "{}"
         pip install -r requirements.txt
         pip install codecov pytest-cov
@@ -163,6 +165,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
+        pip install markupsafe==2.0.1
         grep "numpy" requirements.txt | xargs -I {} pip install "{}"
         pip install -r requirements.txt
 


### PR DESCRIPTION
`pip install markupsafe==2.0.1`

See: https://github.com/aws/aws-sam-cli/issues/3661

