### PR TITLE
remove redundant files LFS

### DIFF
--- a/tests/input/ADP.2021-11-08T12_34_46.383.fits
+++ b/tests/input/ADP.2021-11-08T12_34_46.383.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:180dc91ea06017e38c9af76cd8cf83a1aefc0e018932ec56296566bc2a638f29
-size 71887680

--- a/tests/input/ADP.2021-11-08T12_46_22.832.fits
+++ b/tests/input/ADP.2021-11-08T12_46_22.832.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e223925768ebde91ab5bc76cace959c1462b98a683707bc94f9f036b523b2559
-size 73353600


### PR DESCRIPTION
Removes 2 large files from LFS to lower LFS usage, also stops default copying of LFS files on code checkout without an explicit git lfs call.