### PR TITLE
Fix photometry table row insert sometimes failing due to column mismatch

### DIFF
--- a/flows/photometry.py
+++ b/flows/photometry.py
@@ -329,6 +329,7 @@ def do_phot(fileid: int, cm_timeout: Optional[float] = None, make_plots: bool = 
     diffimage_df = datafile.get('diffimg', None)
     if diffimage_df:
         diffimage_path = diffimage_df.get('path', None)
+        logger.info("Found diffimg: %s, running difference photometry.", diffimage_path)
         if diffimage_path is None:
             logger.warning("No diffimage present but without path, skipping diffimage photometry")
         diffimage = load_image(directories.image_path(diffimage_path), target_coord=target.coords)
@@ -340,8 +341,8 @@ def do_phot(fileid: int, cm_timeout: Optional[float] = None, make_plots: bool = 
         # Store the difference image photometry on row 0 of the table.
         # This pushes the un-subtracted target photometry to row 1.
         clean_references.add_target(target, starid=-1)
-        psfphot_tbl.insert_row(0, diff_psfphot_tbl[0])
-        apphot_tbl.insert_row(0, diff_apphot_tbl[0])
+        psfphot_tbl.insert_row(0, dict(diff_psfphot_tbl[0]))
+        apphot_tbl.insert_row(0, dict(diff_apphot_tbl[0]))
 
 
     # TODO: This should be moved to the photometry manager.

--- a/flows/reference_cleaning.py
+++ b/flows/reference_cleaning.py
@@ -163,7 +163,8 @@ def force_reject_g2d(xarray, yarray, image: FlowsImage, rsq_min=0.5, radius=10, 
         curr_star /= np.nanmax(curr_star)
 
         ypos, xpos = np.mgrid[:curr_star.shape[0], :curr_star.shape[1]]
-        gfit = gfitter(g2d, x=xpos, y=ypos, z=curr_star)
+        nan_filter = np.isfinite(curr_star)  # This shouldn't be necessary if images are properly cleaned?
+        gfit = gfitter(g2d, x=xpos[nan_filter], y=ypos[nan_filter], z=curr_star[nan_filter])
 
         # Center
         xys[i] = np.array([gfit.x_mean + x - radius, gfit.y_mean + y - radius], dtype='float64')


### PR DESCRIPTION
By converting to dictionary, non-matching columns will be set to zero, but the table update won't fail.