### PR TITLE
remove OBS_MODE key from NOTCAM

### DIFF
--- a/flows/instruments/instruments.py
+++ b/flows/instruments/instruments.py
@@ -191,7 +191,7 @@ class NOTCAM(Instrument):
     siteid = 5
     telescope = "NOT"
     instrument = "NOTCAM"
-    unique_headers = {"OBS_MODE": 'IMAGING'}
+    # unique_headers = {"OBS_MODE": 'IMAGING'}  # not needed.
 
     def get_obstime(self):
         return Time(self.image.header['DATE-AVG'], format='isot', scale='utc',


### PR DESCRIPTION
It is redundant with the instrument keyword.

Fixes #112 